### PR TITLE
Support specifying a build path when building images from a string

### DIFF
--- a/lib/dockerspec/builder.rb
+++ b/lib/dockerspec/builder.rb
@@ -64,6 +64,10 @@ module Dockerspec
     #   environment variable and uses `'.'` if it is not set.
     # @option opts [String] :string Use this string as *Dockerfile* instead of
     #   `:path`. Not set by default.
+    # @option opts [String] :string_build_path Used to specify the path that is
+    #    used for the docker build of a string *Dockerfile*. This enables ADD
+    #    statements in the Dockerfile to access files that are outside of .
+    #    Not set by default and overrides the default '.'
     # @option opts [String] :template Use this [Erubis]
     #   (http://www.kuwata-lab.com/erubis/users-guide.html) template file as
     #   *Dockerfile*.
@@ -274,13 +278,16 @@ module Dockerspec
     #
     # @param string [String] The Dockerfile content.
     # @param dir [String] The directory to copy the files from. Files that are
-    #   required by the Dockerfile passed in *string*.
+    #   required by the Dockerfile passed in *string*. If not passed, then
+    #   the 'string_build_path' option is used. If that is not used, '.' is
+    #   assumed.
     #
     # @return void
     #
     # @api private
     #
     def build_from_string(string, dir = '.')
+      dir = @options[:string_build_path] if @options[:string_build_path]
       Dir.mktmpdir do |tmpdir|
         FileUtils.cp_r("#{dir}/.", tmpdir)
         dockerfile = File.join(tmpdir, 'Dockerfile')

--- a/spec/integration/dockerfiles/from_string_spec.rb
+++ b/spec/integration/dockerfiles/from_string_spec.rb
@@ -94,5 +94,21 @@ serverspec_tests do
         end
       end
     end
+    context 'With string_build_path' do
+      Dir.mktmpdir do |dir|
+        File.write("#{dir}/test", 'rspec integration tests')
+        dockerfile_string = "FROM nginx:1.9\nADD test /test"
+        describe docker_build(
+          string: dockerfile_string,
+          string_build_path: dir) do
+          describe docker_run(described_image) do
+            describe command('cat /test') do
+              its(:stdout) { should match(/rspec integration tests/) }
+              its(:exit_status) { should eq 0 }
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -127,6 +127,23 @@ describe Dockerspec::Builder do
           subject.build
         end
       end
+
+      context 'string_build_path option' do
+        let(:subject) do
+          described_class.new(string: string, string_build_path: '/tmp')
+        end
+
+        it 'Handles build with string_build_path specified' do
+          expect(FileUtils).to receive(:cp_r).with('/tmp/.', tmpdir)
+          subject.build
+        end
+
+        it 'Uses the current directory if no value is passed' do
+          subject = described_class.new(string: string)
+          expect(FileUtils).to receive(:cp_r).with('./.', tmpdir)
+          subject.build
+        end
+      end
     end
 
     context 'passing a file to the path option' do


### PR DESCRIPTION
### Description

This change adds an option to `Dockerspec::Builder`, `string_build_path`, which is used by `build_from_string` to support specifying a build directory other than `.`

The use case here is: test cases have directories with various fixtures/assets that need to be included in a build, and I want to be able to chain multiple builds together while also being able to access fixtures/assets during the build. To support this use case, I have an initial build performed (either via a string or a docker file)` images in the example group are built from a string that derives the `FROM` statement using the `Dockerspec::Rspec::Resources#described_image` accessor.

However, the later images cannot add the assets since currently building via the `Dockerspec::Rspec::Resources#docker_build` method does not allow specifying a path when building from a string, and instead defaults to `.`

### Issues Resolved

n/a

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/dockerspec/blob/master/CONTRIBUTING.md).
